### PR TITLE
Adding support for grunt.file.read

### DIFF
--- a/GruntLauncher/Resources/Init.txt
+++ b/GruntLauncher/Resources/Init.txt
@@ -34,7 +34,10 @@ grunt.initConfig=function(param){
 		}
 	}
 };
-grunt.file = { readJSON: function(){return {};}}
+grunt.file = { 
+	read: function(){return {};},
+	readJSON: function(){return {};}
+}
 grunt.registerTask= function(name){names.push(name);};
 grunt.registerMultiTask= function(name){names.push(name);};
 grunt.loadNpmTasks = function(){};


### PR DESCRIPTION
Added read in same fashion as readJSON so that the grunt launcher can parse gruntfiles with tasks that contain grunt.file.read
