### PR TITLE
Fixing encoding issue

### DIFF
--- a/GruntLauncher/GruntLauncherPackage.cs
+++ b/GruntLauncher/GruntLauncherPackage.cs
@@ -488,6 +488,8 @@
                 {
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8,
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     WorkingDirectory = fromRoot ? SolutionHelpers.GetRootFolder(dte) : Path.GetDirectoryName(SolutionHelpers.GetSourceFilePath()),


### PR DESCRIPTION
The weird characters in the output window are caused by incorrect encoding. This fixes it
