### PR TITLE
Kill running processes when build starts

### DIFF
--- a/GruntLauncher/GruntLauncherPackage.cs
+++ b/GruntLauncher/GruntLauncherPackage.cs
@@ -49,9 +49,15 @@
         /// The DTE object of Visual Studio
         /// </summary>
         private static DTE2 dte;
-
-        private static string exclusionRegex { get; set; }
-
+        
+        /// <summary>
+        /// Returns the instance of the OptionPage.
+        /// </summary>
+        private OptionPage Options
+        {
+            get { return (OptionPage) GetDialogPage(typeof (OptionPage)); }
+        }
+        
 
         /// <summary>
         ///     Default constructor of the package.
@@ -82,9 +88,6 @@
 
             env.Events.BuildEvents.OnBuildBegin += OnOnBuildBegin;
 
-            EnvDTE.Properties props = env.get_Properties("Grunt Launcher", "General");
-
-            exclusionRegex = (string)props.Item("TaskRegex").Value;
 
             // Add our command handlers for menu (commands must exist in the .vsct file)
             OleMenuCommandService mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
@@ -123,6 +126,9 @@
 
         private void OnOnBuildBegin(vsBuildScope scope, vsBuildAction action)
         {
+            if (!Options.StopProcessesOnBuild)
+                return;
+
             foreach (var process in processes)
                 ProcessHelpers.KillProcessAndChildren(process.Value.Id);
 
@@ -284,7 +290,7 @@
                     list.Remove("default");
                 }
 
-                string n = exclusionRegex;
+                string n = Options.TaskRegex;
 
                 Regex a = null;
 
@@ -420,7 +426,7 @@
                     list.Remove("default");
                 }
 
-                string n = exclusionRegex;
+                string n = Options.TaskRegex;
 
                 Regex a = null;
 

--- a/GruntLauncher/GruntLauncherPackage.cs
+++ b/GruntLauncher/GruntLauncherPackage.cs
@@ -12,8 +12,7 @@
     using EnvDTE;
     using System.Text.RegularExpressions;
     using System.Text;
-
-
+    
 
     /// <summary>
     ///     Main class that implements the gruntLauncher packages
@@ -53,6 +52,7 @@
 
         private static string exclusionRegex { get; set; }
 
+
         /// <summary>
         ///     Default constructor of the package.
         ///     Inside this method you can place any initialization code that does not require 
@@ -79,6 +79,8 @@
             dte = GetService(typeof(DTE)) as DTE2;
 
             DTE env = (DTE)GetService(typeof(DTE));
+
+            env.Events.BuildEvents.OnBuildBegin += OnOnBuildBegin;
 
             EnvDTE.Properties props = env.get_Properties("Grunt Launcher", "General");
 
@@ -117,6 +119,14 @@
                 bow.BeforeQueryStatus += BowerInstallBeforeQueryStatus;
                 mcs.AddCommand(bow);
             }
+        }
+
+        private void OnOnBuildBegin(vsBuildScope scope, vsBuildAction action)
+        {
+            foreach (var process in processes)
+                ProcessHelpers.KillProcessAndChildren(process.Value.Id);
+
+            processes = new Dictionary<OleMenuCommand, System.Diagnostics.Process>();
         }
 
         private void BowerInstallBeforeQueryStatus(object sender, EventArgs e)

--- a/GruntLauncher/OptionPage.cs
+++ b/GruntLauncher/OptionPage.cs
@@ -13,11 +13,25 @@ namespace Bjornej.GruntLauncher
     [CLSCompliant(false), ComVisible(true)]
     public class OptionPage : DialogPage
     {
+        #region Constants
+
+        public const string TaskRegexKey = "TaskRegex";
+        public const string StopProcessesOnBuildKey = "StopProcessesOnBuild";
+
+        #endregion
 
         [Category("Tasks Parser")]
         [DisplayName("Exclusion")]
         [Description("Specify a Regex pattern to exclude some unwanted tasks from list.")]
         public string TaskRegex
+        {
+            get; set;
+        }
+
+        [Category("Build")]
+        [DisplayName("Stop processes before building")]
+        [Description("Stop running grunt tasks when a (re)build is started. For instance, this can be useful when running 'watch' task from Visual Studio and executing 'npm install' when building.")]
+        public bool StopProcessesOnBuild
         {
             get; set;
         }


### PR DESCRIPTION
When executing a grunt task like "watch", it can make the build fail.
This modification kills all running processes when build starts.