### PR TITLE
Add message to output when command has exited.

### DIFF
--- a/GruntLauncher/GruntLauncherPackage.cs
+++ b/GruntLauncher/GruntLauncherPackage.cs
@@ -557,7 +557,7 @@
                     processes.Remove(cmd);
                     cmd.Checked = false;
                     dte.StatusBar.Animate(false, vsStatusAnimation.vsStatusAnimationBuild);
-                    OutputHelpers.Output("Execeution of " + command + " completed.\r\n\r\n", true);
+                    OutputHelpers.Output("Execution of " + command + " completed.\r\n\r\n", true);
                 };
 
                 proc.Start();

--- a/GruntLauncher/GruntLauncherPackage.cs
+++ b/GruntLauncher/GruntLauncherPackage.cs
@@ -547,7 +547,8 @@
                     EnableRaisingEvents = true
                 };
 
-                OutputHelpers.Output("Executing " + cmd.Text + " \r\n\r\n", true);
+                string command = cmd.Text;
+                OutputHelpers.Output("Executing " + command + " \r\n\r\n", true);
 
                 proc.OutputDataReceived += (object sendingProcess, DataReceivedEventArgs outLine) => OutputHelpers.Output(outLine.Data + "\r\n");
                 proc.ErrorDataReceived += (object sendingProcess, DataReceivedEventArgs outLine) => OutputHelpers.Output(outLine.Data + "\r\n");
@@ -556,6 +557,7 @@
                     processes.Remove(cmd);
                     cmd.Checked = false;
                     dte.StatusBar.Animate(false, vsStatusAnimation.vsStatusAnimationBuild);
+                    OutputHelpers.Output("Execeution of " + command + " completed.\r\n\r\n", true);
                 };
 
                 proc.Start();


### PR DESCRIPTION
Update the RunProcess method to output that a task has been completed when the process exits. Easier to notice than an icon disappearing.
